### PR TITLE
Add current account advance agreement generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Ce projet propose un utilitaire en ligne de commande permettant d'importer une *
 - Repérage des comptes absents d'un fichier par rapport à l'autre et des écarts significatifs de solde.
 - Synthèse de l'activité mensuelle et liste des écritures les plus significatives.
 - Génération d'un rapport au format Markdown prêt à être partagé.
+- Création d'une convention d'avance en compte courant personnalisable.
 
 ## Formats attendus
 
@@ -50,6 +51,65 @@ python main.py --balance examples/balance_generale.csv --ledger examples/grand_l
 ```
 
 Le fichier `revue_exemple.md` contiendra une revue comptable synthétique basée sur les données d'exemple.
+
+## Générateur de convention d'avance en compte courant
+
+Le paquet expose également un utilitaire pour rédiger automatiquement une convention d'avance en compte courant entre deux parties.
+Il suffit de décrire chacune des sociétés signataires et les principales caractéristiques de l'avance.
+
+```python
+from datetime import date
+from decimal import Decimal
+
+from revue_comptable import (
+    AdvanceTerms,
+    PartyInfo,
+    generate_current_account_advance_agreement,
+)
+
+lender = PartyInfo(
+    name="Holding Invest",
+    legal_form="SAS",
+    share_capital="1 000 000 EUR",
+    registration_city="Paris",
+    registration_number="799 999 999",
+    address="10 avenue de l'Europe, 75008 Paris",
+    representative="Marie Martin",
+    representative_title="Présidente",
+)
+
+borrower = PartyInfo(
+    name="Projet Solaire 5",
+    legal_form="SASU",
+    share_capital="10 000 EUR",
+    registration_city="Nanterre",
+    registration_number="910 000 111",
+    address="22 rue des Fleurs, 92000 Nanterre",
+    representative="Julien Petit",
+    representative_title="Président",
+)
+
+terms = AdvanceTerms(
+    purpose="le financement du besoin en fonds de roulement",
+    amount=Decimal("250000"),
+    interest_rate=Decimal("3.5"),
+    availability_date=date(2024, 1, 15),
+    repayment_date=date(2024, 12, 31),
+    remuneration_description="Les intérêts sont calculés au taux annuel fixe de 3,5 % sur la base des jours exacts/360.",
+)
+
+agreement = generate_current_account_advance_agreement(
+    lender=lender,
+    borrower=borrower,
+    terms=terms,
+    signature_city="Paris",
+    signature_date=date(2024, 1, 10),
+)
+
+print(agreement)
+```
+
+Le texte généré est fourni au format Markdown et peut être envoyé tel quel aux parties prenantes ou inséré dans un modèle bureautique.
 
 ## Limites connues
 

--- a/revue_comptable/__init__.py
+++ b/revue_comptable/__init__.py
@@ -3,6 +3,11 @@
 from .model import TrialBalanceEntry, LedgerEntry
 from .io import read_trial_balance, read_general_ledger
 from .review import generate_accounting_review
+from .convention import (
+    AdvanceTerms,
+    PartyInfo,
+    generate_current_account_advance_agreement,
+)
 
 __all__ = [
     "TrialBalanceEntry",
@@ -10,4 +15,7 @@ __all__ = [
     "read_trial_balance",
     "read_general_ledger",
     "generate_accounting_review",
+    "PartyInfo",
+    "AdvanceTerms",
+    "generate_current_account_advance_agreement",
 ]

--- a/revue_comptable/convention.py
+++ b/revue_comptable/convention.py
@@ -1,0 +1,160 @@
+"""Générateur de conventions d'avance en compte courant."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class PartyInfo:
+    """Informations d'une entité signataire de la convention."""
+
+    name: str
+    legal_form: str
+    share_capital: str
+    registration_city: str
+    registration_number: str
+    address: str
+    representative: str
+    representative_title: str
+
+    def to_markdown(self) -> str:
+        return (
+            f"**{self.name}**, {self.legal_form} au capital de {self.share_capital},"
+            f" immatriculée au RCS de {self.registration_city} sous le numéro {self.registration_number},"
+            f" dont le siège social est situé {self.address}, représentée par {self.representative},"
+            f" en qualité de {self.representative_title}."
+        )
+
+
+@dataclass(frozen=True)
+class AdvanceTerms:
+    """Paramètres décrivant l'avance consentie."""
+
+    purpose: str
+    amount: Decimal
+    currency: str = "EUR"
+    availability_date: date
+    repayment_date: date
+    interest_rate: Optional[Decimal] = None
+    remuneration_description: Optional[str] = None
+    repayment_terms: str = "L'avance est remboursable à tout moment à la demande du prêteur."
+    termination_conditions: str = (
+        "Chacune des parties pourra mettre fin à la présente convention moyennant un préavis de 15 jours par lettre recommandée."
+    )
+    confidentiality_clause: str = (
+        "Les informations échangées dans le cadre de la présente convention sont confidentielles et ne peuvent être divulguées qu'avec l'accord écrit de l'autre partie."
+    )
+    governing_law: str = "Droit français"
+
+
+def _format_amount(value: Decimal, currency: str) -> str:
+    quantized = value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    formatted = f"{quantized:,.2f}".replace(",", " ").replace(".", ",")
+    return f"{formatted} {currency}"
+
+
+def _format_date(value: date) -> str:
+    return value.strftime("%d/%m/%Y")
+
+
+def _format_interest(interest_rate: Optional[Decimal], description: Optional[str]) -> str:
+    if description:
+        return description
+    if interest_rate is None:
+        return "L'avance est consentie à titre gratuit et ne porte pas intérêt."
+    rate = interest_rate.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    return (
+        "L'avance porte intérêt au taux annuel fixe de "
+        f"{rate.normalize()} % calculé sur la base du nombre exact de jours écoulés sur 360 jours."
+    )
+
+
+def generate_current_account_advance_agreement(
+    lender: PartyInfo,
+    borrower: PartyInfo,
+    terms: AdvanceTerms,
+    signature_city: str,
+    signature_date: date,
+) -> str:
+    """Produit une convention prête à partager au format Markdown."""
+
+    amount = _format_amount(terms.amount, terms.currency)
+    availability_date = _format_date(terms.availability_date)
+    repayment_date = _format_date(terms.repayment_date)
+    remuneration = _format_interest(terms.interest_rate, terms.remuneration_description)
+    signature = _format_date(signature_date)
+
+    lines = ["# Convention d'avance en compte courant", ""]
+    lines.append("**Entre les soussignés :**")
+    lines.append("- " + lender.to_markdown())
+    lines.append("- " + borrower.to_markdown())
+    lines.append("")
+
+    lines.append("Collectivement désignés les « Parties » et individuellement une « Partie ».")
+    lines.append("")
+    lines.append("## Préambule")
+    lines.append(
+        f"Le prêteur souhaite soutenir la trésorerie de l'emprunteur en mettant à sa disposition une avance en compte courant "
+        f"afin de financer {terms.purpose}."
+    )
+    lines.append(
+        "Les Parties se sont rapprochées pour formaliser les conditions de cette avance conformément aux dispositions du Code de commerce."
+    )
+    lines.append("")
+
+    lines.append("## Article 1 – Objet")
+    lines.append(
+        f"La présente convention a pour objet de fixer les modalités de l'avance en compte courant consentie par {lender.name}"
+        f" au profit de {borrower.name}."
+    )
+    lines.append("")
+
+    lines.append("## Article 2 – Montant et mise à disposition")
+    lines.append(
+        f"Le montant maximum de l'avance est fixé à {amount}. Elle sera mise à disposition de l'emprunteur à compter du {availability_date}"
+        " par simple transfert sur le compte bancaire habituel."
+    )
+    lines.append("L'avance est enregistrée en compte courant d'associé et pourra faire l'objet de tirages successifs dans la limite du montant autorisé.")
+    lines.append("")
+
+    lines.append("## Article 3 – Rémunération")
+    lines.append(remuneration)
+    lines.append("")
+
+    lines.append("## Article 4 – Remboursement")
+    lines.append(
+        f"L'emprunteur remboursera intégralement l'avance au plus tard le {repayment_date}. {terms.repayment_terms}"
+    )
+    lines.append("Tout remboursement partiel viendra en priorité apurer les intérêts échus avant d'imputer le capital restant dû.")
+    lines.append("")
+
+    lines.append("## Article 5 – Déclarations et engagements")
+    lines.append(
+        f"{borrower.name} s'engage à informer sans délai {lender.name} de tout événement susceptible d'affecter sa capacité à honorer ses engagements."
+    )
+    lines.append(terms.confidentiality_clause)
+    lines.append("")
+
+    lines.append("## Article 6 – Résiliation")
+    lines.append(terms.termination_conditions)
+    lines.append("En cas de manquement grave par l'une des Parties, l'autre Partie pourra exiger le remboursement immédiat de l'avance.")
+    lines.append("")
+
+    lines.append("## Article 7 – Loi applicable et juridiction compétente")
+    lines.append(
+        f"La présente convention est régie par le {terms.governing_law}. Tout différend relatif à son interprétation ou son exécution sera soumis aux tribunaux compétents du ressort de {signature_city}."
+    )
+    lines.append("")
+
+    lines.append("## Signatures")
+    lines.append(f"Fait à {signature_city}, le {signature}.")
+    lines.append("")
+    lines.append("Pour le prêteur")
+    lines.append("")
+    lines.append("Pour l'emprunteur")
+
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- add PartyInfo and AdvanceTerms dataclasses plus a Markdown generator for current-account advance agreements
- expose the new API through the public package surface and document how to use it in the README

## Testing
- python -m compileall revue_comptable

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df10bd4f4832d8a0143335f29e226)